### PR TITLE
Add scripting permission to manifest

### DIFF
--- a/.changeset/sour-gifts-attend.md
+++ b/.changeset/sour-gifts-attend.md
@@ -1,0 +1,5 @@
+---
+"snip-lab": minor
+---
+
+add permissions to manifest to execute scripts

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -11,7 +11,8 @@
     "128": "icon-128.png"
   },
   "permissions": [
-    "storage"
+    "storage",
+    "scripting"
   ],
   "host_permissions": [
     "<all_urls>"


### PR DESCRIPTION
## Summary
- allow programmatic script execution by adding `scripting` permission

## Testing
- `npm run lint`
- `npm test`
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_6873e8bc40308320a5000189c778be74