### PR TITLE
Improve devtools readiness logic

### DIFF
--- a/src/pages/Devtools/__tests__/panelOpened.test.ts
+++ b/src/pages/Devtools/__tests__/panelOpened.test.ts
@@ -15,17 +15,29 @@ describe('Devtools panel open telemetry', () => {
     const evalMock = jest.fn((_expr: string, cb: (val: any) => void) =>
       cb('example.com')
     );
+    let createCallback: () => void = jest.fn();
+    const createMock = jest.fn(
+      (
+        _title: string,
+        _icon: string,
+        _page: string,
+        cb: () => void
+      ) => {
+        createCallback = cb;
+      }
+    );
     (globalThis as any).chrome = {
       tabs: { sendMessage: jest.fn() },
       devtools: {
         inspectedWindow: { eval: evalMock },
-        panels: { create: jest.fn() },
+        panels: { create: createMock },
       },
       runtime: { onMessage: { addListener: jest.fn() } },
     } as any;
 
     jest.isolateModules(() => {
       require('../index');
+      createCallback();
     });
 
     const { trackEvent } = require('../../../utils/telemetry');

--- a/src/store/devtoolsSlice.ts
+++ b/src/store/devtoolsSlice.ts
@@ -1,0 +1,29 @@
+import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+
+interface DevtoolsState {
+  isReady: boolean;
+  contentScriptReady: boolean;
+}
+
+const initialState: DevtoolsState = {
+  isReady: false,
+  contentScriptReady: false,
+};
+
+const devtoolsSlice = createSlice({
+  name: 'devtoolsPanel',
+  initialState,
+  reducers: {
+    setDevtoolsPanelReady(state, action: PayloadAction<boolean>) {
+      state.isReady = action.payload;
+    },
+    setContentScriptReady(state, action: PayloadAction<boolean>) {
+      state.contentScriptReady = action.payload;
+    },
+  },
+});
+
+export const { setDevtoolsPanelReady, setContentScriptReady } =
+  devtoolsSlice.actions;
+
+export default devtoolsSlice.reducer;


### PR DESCRIPTION
## Summary
- track when the devtools panel and content script are ready
- gate sending state messages on readiness
- reset readiness when devtools closes
- send hostname telemetry after panel creation
- fix devtools telemetry tests

## Testing
- `npm run type-check`
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6873f04458cc832098b02667f3ff64f1