### PR TITLE
Fix script execution context

### DIFF
--- a/src/pages/Background/index.ts
+++ b/src/pages/Background/index.ts
@@ -9,6 +9,7 @@ chrome.runtime.onMessage.addListener((message, sender) => {
           eval(code);
         },
         args: [message.script.code],
+        world: 'MAIN',
       });
     }
   }


### PR DESCRIPTION
## Summary
- ensure `chrome.scripting.executeScript` injects scripts in the main world
- verify manifest includes the `scripting` permission

## Testing
- `npm run lint`
- `npm test`
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_68743714e9648320815dfc20b700e153