### PR TITLE
Add Monaco editor for script code

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,10 +9,12 @@
       "version": "1.12.0",
       "license": "MIT",
       "dependencies": {
+        "@monaco-editor/react": "^4.7.0",
         "@reduxjs/toolkit": "*",
         "class-variance-authority": "*",
         "clsx": "*",
         "lucide-react": "*",
+        "monaco-editor": "^0.52.2",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-redux": "*",
@@ -4123,6 +4125,29 @@
       "dev": true,
       "engines": {
         "node": ">= 4.0.0"
+      }
+    },
+    "node_modules/@monaco-editor/loader": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@monaco-editor/loader/-/loader-1.5.0.tgz",
+      "integrity": "sha512-hKoGSM+7aAc7eRTRjpqAZucPmoNOC4UUbknb/VNoTkEIkCPhqV8LfbsgM1webRM7S/z21eHEx9Fkwx8Z/C/+Xw==",
+      "license": "MIT",
+      "dependencies": {
+        "state-local": "^1.0.6"
+      }
+    },
+    "node_modules/@monaco-editor/react": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/@monaco-editor/react/-/react-4.7.0.tgz",
+      "integrity": "sha512-cyzXQCtO47ydzxpQtCGSQGOC8Gk3ZUeBXFAxD+CWXYFo5OqZyZUonFl0DwUlTyAfRHntBfw2p3w4s9R6oe1eCA==",
+      "license": "MIT",
+      "dependencies": {
+        "@monaco-editor/loader": "^1.5.0"
+      },
+      "peerDependencies": {
+        "monaco-editor": ">= 0.25.0 < 1",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/@nicolo-ribaudo/eslint-scope-5-internals": {
@@ -14717,6 +14742,12 @@
         "node": ">=10"
       }
     },
+    "node_modules/monaco-editor": {
+      "version": "0.52.2",
+      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.52.2.tgz",
+      "integrity": "sha512-GEQWEZmfkOGLdd3XK8ryrfWz3AIP8YymVXiPHEdewrUq7mh0qrKrfHLNCXcbB6sTnMLnOZ3ztSiKcciFUkIJwQ==",
+      "license": "MIT"
+    },
     "node_modules/mri": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/mri/-/mri-1.2.0.tgz",
@@ -18230,6 +18261,12 @@
       "resolved": "https://registry.npmjs.org/stackframe/-/stackframe-1.3.4.tgz",
       "integrity": "sha512-oeVtt7eWQS+Na6F//S4kJ2K2VbRlS9D43mAlMyVpVWovy9o+jfgH8O9agzANzaiLjclA0oYzUXEM4PurhSUChw==",
       "dev": true
+    },
+    "node_modules/state-local": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/state-local/-/state-local-1.0.7.tgz",
+      "integrity": "sha512-HTEHMNieakEnoe33shBYcZ7NX83ACUjCu8c40iOGEZsngj9zRnkqS9j1pqQPXwobB0ZcVTk27REb7COQ0UR59w==",
+      "license": "MIT"
     },
     "node_modules/statuses": {
       "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -31,10 +31,12 @@
     "changeset": "npx changeset"
   },
   "dependencies": {
+    "@monaco-editor/react": "^4.7.0",
     "@reduxjs/toolkit": "*",
     "class-variance-authority": "*",
     "clsx": "*",
     "lucide-react": "*",
+    "monaco-editor": "^0.52.2",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-redux": "*",

--- a/src/components/ScriptForm.tsx
+++ b/src/components/ScriptForm.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from 'react';
+import Editor from '@monaco-editor/react';
 import { useAppDispatch } from '../store';
 import { addScript, updateScript } from '../store/scriptSlice';
 import type { Script } from '../types/script';
@@ -41,13 +42,20 @@ const ScriptForm: React.FC<ScriptFormProps> = ({ script, onSave }) => {
         onChange={(e) => setName(e.target.value)}
         className="w-full rounded border px-2 py-1 text-black"
       />
-      <textarea
-        placeholder="Code"
-        value={code}
-        onChange={(e) => setCode(e.target.value)}
-        className="w-full rounded border px-2 py-1 font-mono text-black"
-        rows={6}
-      />
+      <div className="border rounded overflow-hidden">
+        <Editor
+          height="300px"
+          defaultLanguage="javascript"
+          value={code}
+          onChange={(value) => setCode(value ?? '')}
+          theme="vs-dark"
+          options={{
+            fontSize: 14,
+            minimap: { enabled: false },
+            automaticLayout: true,
+          }}
+        />
+      </div>
       <button type="submit" className="rounded bg-blue-600 px-2 py-1 text-white">
         Save
       </button>


### PR DESCRIPTION
## Summary
- add Monaco Editor dependencies
- replace textarea with Monaco Editor in ScriptForm

## Testing
- `npm run lint`
- `npm run type-check`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687442be46fc8320911dd3577998c12c