### PR TITLE
Integrate react-complex-tree

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "clsx": "*",
         "lucide-react": "*",
         "react": "^18.2.0",
+        "react-complex-tree": "^2.6.0",
         "react-dom": "^18.2.0",
         "react-redux": "*",
         "tailwind-merge": "*",
@@ -16853,6 +16854,18 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-complex-tree": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/react-complex-tree/-/react-complex-tree-2.6.0.tgz",
+      "integrity": "sha512-kDDuWih5VUz9cXgTKGnDBnMMoM4lvbn3/yCPs2D0jI9Z724BNeraeA5yBqyKqbIRhESQOlCyAyYW9WUqljFP1Q==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/lukasbach"
+      },
+      "peerDependencies": {
+        "react": ">=16.0.0"
       }
     },
     "node_modules/react-dom": {

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "clsx": "*",
     "lucide-react": "*",
     "react": "^18.2.0",
+    "react-complex-tree": "^2.6.0",
     "react-dom": "^18.2.0",
     "react-redux": "*",
     "tailwind-merge": "*",

--- a/src/store/__tests__/storePersistence.test.ts
+++ b/src/store/__tests__/storePersistence.test.ts
@@ -38,15 +38,17 @@ describe('store persistence', () => {
           code: 'console.log(1);',
         },
       ],
+      items: {},
     };
     createChromeMocks(stored);
     const { store } = await import('../index');
     expect(store.getState().settings.patched).toBe(true);
     expect(store.getState().scripts).toEqual(stored.scripts);
+    expect(store.getState().items).toEqual({});
   });
 
   it('persists updates to chrome.storage.local', async () => {
-    const stored = { settings: { patched: false }, scripts: [] };
+    const stored = { settings: { patched: false }, scripts: [], items: {} };
     const { setMock } = createChromeMocks(stored);
     const { store } = await import('../index');
 
@@ -54,6 +56,7 @@ describe('store persistence', () => {
     expect(setMock).toHaveBeenLastCalledWith({
       settings: { patched: true },
       scripts: [],
+      items: {},
     });
 
     store.dispatch(
@@ -66,6 +69,7 @@ describe('store persistence', () => {
     expect(setMock).toHaveBeenLastCalledWith({
       settings: { patched: true },
       scripts: expect.any(Array),
+      items: {},
     });
     const lastCall = setMock.mock.calls[setMock.mock.calls.length - 1][0];
     expect(lastCall.scripts).toHaveLength(1);

--- a/src/store/itemsSlice.ts
+++ b/src/store/itemsSlice.ts
@@ -1,0 +1,85 @@
+import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+import { v4 as uuidv4 } from 'uuid';
+import type { ListItems, ListItem, ItemData } from '../types/script';
+
+export type ItemsState = ListItems;
+
+const initialState: ItemsState = {};
+
+const itemsSlice = createSlice({
+  name: 'items',
+  initialState,
+  reducers: {
+    addScript: {
+      reducer(state, action: PayloadAction<ListItem>) {
+        state[action.payload.index] = action.payload;
+      },
+      prepare(data: { name: string; code: string; parentId?: string }) {
+        const id = uuidv4();
+        const item: ListItem = {
+          index: id,
+          children: [],
+          isFolder: false,
+          data: { type: 'script', script: { id, name: data.name, description: '', code: data.code, parentId: data.parentId } },
+        };
+        return { payload: item };
+      },
+    },
+    addFolder: {
+      reducer(state, action: PayloadAction<ListItem>) {
+        state[action.payload.index] = action.payload;
+      },
+      prepare(data: { name: string; parentId?: string }) {
+        const id = uuidv4();
+        const item: ListItem = {
+          index: id,
+          children: [],
+          isFolder: true,
+          data: { type: 'folder', folder: { id, name: data.name, parentId: data.parentId } },
+        };
+        return { payload: item };
+      },
+    },
+    updateItem(state, action: PayloadAction<{ id: string; changes: Partial<ItemData> }>) {
+      const item = state[action.payload.id];
+      if (item) {
+        item.data = { ...item.data, ...action.payload.changes } as ItemData;
+      }
+    },
+    deleteItem(state, action: PayloadAction<string>) {
+      const remove = (id: string | number) => {
+        const item = state[id];
+        if (!item) return;
+        if (item.children) item.children.forEach(remove);
+        delete state[id];
+      };
+      remove(action.payload);
+    },
+    moveItem(state, action: PayloadAction<{ id: string; newParentId: string | undefined }>) {
+      const { id, newParentId } = action.payload;
+      const item = state[id];
+      if (!item) return;
+      // remove from old parent's children
+      const oldParentId = (item.data.type === 'script' ? item.data.script.parentId : item.data.folder.parentId) || undefined;
+      if (oldParentId && state[oldParentId]) {
+        state[oldParentId].children = state[oldParentId].children?.filter((cid) => cid !== id) || [];
+      }
+      // add to new parent
+      if (newParentId && state[newParentId]) {
+        state[newParentId].children = [...(state[newParentId].children || []), id];
+      }
+      if (item.data.type === 'script') {
+        item.data.script.parentId = newParentId;
+      } else {
+        item.data.folder.parentId = newParentId;
+      }
+    },
+    setItems(_state, action: PayloadAction<ItemsState>) {
+      return action.payload;
+    },
+  },
+});
+
+export const { addScript, addFolder, updateItem, deleteItem, moveItem, setItems } = itemsSlice.actions;
+
+export default itemsSlice.reducer;

--- a/src/types/script.ts
+++ b/src/types/script.ts
@@ -1,3 +1,5 @@
+import type { TreeItem, TreeItemIndex } from 'react-complex-tree';
+
 export interface Script {
   id: string;
   name: string;
@@ -9,3 +11,18 @@ export interface Script {
    */
   parentId?: string;
 }
+
+export interface Folder {
+  id: string;
+  name: string;
+  /** Optional parent folder */
+  parentId?: string;
+}
+
+export type ItemData =
+  | { type: 'script'; script: Script }
+  | { type: 'folder'; folder: Folder };
+
+export type ListItem = TreeItem<ItemData>;
+
+export type ListItems = Record<TreeItemIndex, ListItem>;


### PR DESCRIPTION
## Summary
- add `react-complex-tree` dependency
- create item types to match tree items
- implement `itemsSlice` for tree state management
- persist `items` slice in Redux store
- render scripts with `Tree` component in panel
- update persistence tests

## Testing
- `npm run type-check`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6878969ec18083209ab80701de5821e4