### PR TITLE
feat(scriptform): dynamic CodeMirror resizing

### DIFF
--- a/src/components/ScriptForm.tsx
+++ b/src/components/ScriptForm.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useRef } from 'react';
-import CodeMirror from '@uiw/react-codemirror';
+import CodeMirror, { ReactCodeMirrorRef } from '@uiw/react-codemirror';
 import { javascript } from '@codemirror/lang-javascript';
 import { useAppDispatch } from '../store';
 import { addScript, updateScript } from '../store/scriptSlice';
@@ -15,6 +15,7 @@ const ScriptForm: React.FC<ScriptFormProps> = ({ script, onSave }) => {
   const [name, setName] = useState(script?.name || '');
   const [code, setCode] = useState(script?.code || '');
   const saveTimeout = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const codeMirrorRef = useRef<ReactCodeMirrorRef>(null);
 
   useEffect(() => {
     if (script) {
@@ -54,6 +55,28 @@ const ScriptForm: React.FC<ScriptFormProps> = ({ script, onSave }) => {
     };
   }, [name, code, script?.id, dispatch]);
 
+  // Resize CodeMirror editor when the window size changes
+  useEffect(() => {
+    const handleResize = () => {
+      const container = codeMirrorRef.current?.editor;
+      if (container) {
+        const parent = container.parentElement;
+        if (parent) {
+          const newWidth = parent.clientWidth;
+          const offsetTop = parent.getBoundingClientRect().top;
+          const availableHeight = window.innerHeight - offsetTop - 200;
+          container.style.width = `${newWidth}px`;
+          container.style.height = `${Math.max(200, availableHeight)}px`;
+          codeMirrorRef.current?.view?.requestMeasure();
+        }
+      }
+    };
+
+    window.addEventListener('resize', handleResize);
+    handleResize();
+    return () => window.removeEventListener('resize', handleResize);
+  }, []);
+
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
     if (saveTimeout.current) {
@@ -86,6 +109,7 @@ const ScriptForm: React.FC<ScriptFormProps> = ({ script, onSave }) => {
         onChange={(value) => setCode(value)}
         theme="dark"
         className="w-full rounded border"
+        ref={codeMirrorRef}
       />
       {!script && (
         <button type="submit" className="rounded bg-blue-600 px-2 py-1 text-white">

--- a/src/components/__tests__/ScriptForm.test.tsx
+++ b/src/components/__tests__/ScriptForm.test.tsx
@@ -4,10 +4,16 @@ import ScriptForm from '../ScriptForm';
 import { updateScript, addScript } from '../../store/scriptSlice';
 
 jest.mock('@uiw/react-codemirror', () => {
-  const MockCodeMirror = (props: any) => {
+  const MockCodeMirror = React.forwardRef((props: any, ref) => {
     const { value, onChange } = props;
-    return <textarea value={value} onChange={(e) => onChange(e.target.value)} />;
-  };
+    return (
+      <textarea
+        ref={ref as React.RefObject<HTMLTextAreaElement>}
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+      />
+    );
+  });
   MockCodeMirror.displayName = 'MockCodeMirror';
   return MockCodeMirror;
 });


### PR DESCRIPTION
## Summary
- keep ref to CodeMirror instance in ScriptForm
- adjust CodeMirror size on window resize
- update mock component to forward refs for tests

## Testing
- `npm run lint`
- `npm run type-check`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68795426d4888320abe855d033cf35eb