### PR TITLE
feat(panel): streamline snippet creation

### DIFF
--- a/src/components/ScriptForm.tsx
+++ b/src/components/ScriptForm.tsx
@@ -3,6 +3,7 @@ import CodeMirror from '@uiw/react-codemirror';
 import { javascript } from '@codemirror/lang-javascript';
 import { useAppDispatch } from '../store';
 import { addScript, updateScript } from '../store/scriptSlice';
+import { v4 as uuidv4 } from 'uuid';
 import type { Script } from '../types/script';
 
 interface ScriptFormProps {
@@ -63,7 +64,10 @@ const ScriptForm: React.FC<ScriptFormProps> = ({ script, onSave }) => {
     if (script) {
       dispatch(updateScript({ id: script.id, changes: { name, code } }));
     } else {
-      dispatch(addScript({ name, description: '', code }));
+      console.warn(
+        'ScriptForm: Adding new script directly from form (not via "Create New Snippet" button).'
+      );
+      dispatch(addScript({ id: uuidv4(), name, description: '', code }));
       setName('');
       setCode('');
     }

--- a/src/components/__tests__/ScriptForm.test.tsx
+++ b/src/components/__tests__/ScriptForm.test.tsx
@@ -65,6 +65,7 @@ describe('ScriptForm auto-save', () => {
       expect.objectContaining({
         type: 'scripts/addScript',
         payload: expect.objectContaining({
+          id: expect.any(String),
           name: 'new',
           description: '',
           code: '',

--- a/src/pages/Panel/Panel.tsx
+++ b/src/pages/Panel/Panel.tsx
@@ -3,14 +3,30 @@ import { X } from 'lucide-react';
 import ScriptForm from '../../components/ScriptForm';
 import ScriptList from '../../components/ScriptList';
 import type { Script } from '../../types/script';
+import { useAppDispatch, useAppSelector } from '../../store';
+import { addScript } from '../../store/scriptSlice';
+import { v4 as uuidv4 } from 'uuid';
 
 interface PanelProps {
   inspectedTabId: number;
 }
 
 const Panel: React.FC<PanelProps> = ({ inspectedTabId }) => {
-  const [editing, setEditing] = useState<Script | null>(null);
+  const dispatch = useAppDispatch();
+  const scripts = useAppSelector((state) => state.scripts);
+  const [editingScript, setEditingScript] = useState<Script | null>(null);
   const [filter, setFilter] = useState('');
+
+  const handleAddNewScript = () => {
+    const newScript: Script = {
+      id: uuidv4(),
+      name: `Snippet #${scripts.length + 1}`,
+      description: '',
+      code: '// Your JavaScript code here',
+    };
+    dispatch(addScript(newScript));
+    setEditingScript(newScript);
+  };
 
   return (
     <div className="flex flex-col min-h-screen bg-zinc-800 p-4 text-white">
@@ -37,9 +53,9 @@ const Panel: React.FC<PanelProps> = ({ inspectedTabId }) => {
             </div>
             <button
               className="rounded bg-blue-600 px-2 py-1 text-white"
-              onClick={() => setEditing(null)}
+              onClick={handleAddNewScript}
             >
-              Add New Snippet
+              Create New Snippet
             </button>
           </div>
           <ScriptList
@@ -50,12 +66,15 @@ const Panel: React.FC<PanelProps> = ({ inspectedTabId }) => {
                 tabId: inspectedTabId,
               });
             }}
-            onEdit={(s) => setEditing(s)}
+            onEdit={setEditingScript}
             filterText={filter}
           />
         </div>
         <div className="w-2/3 overflow-y-auto pl-4">
-          <ScriptForm script={editing || undefined} onSave={() => setEditing(null)} />
+          <ScriptForm
+            script={editingScript || undefined}
+            onSave={() => setEditingScript(null)}
+          />
         </div>
       </div>
     </div>

--- a/src/store/__tests__/storePersistence.test.ts
+++ b/src/store/__tests__/storePersistence.test.ts
@@ -1,5 +1,6 @@
 import { setPatched } from '../settingsSlice';
 import { addScript } from '../scriptSlice';
+import { v4 as uuidv4 } from 'uuid';
 
 describe('store persistence', () => {
   beforeEach(() => {
@@ -58,6 +59,7 @@ describe('store persistence', () => {
 
     store.dispatch(
       addScript({
+        id: uuidv4(),
         name: 'demo',
         description: '',
         code: 'console.log(1);',

--- a/src/store/scriptSlice.ts
+++ b/src/store/scriptSlice.ts
@@ -1,6 +1,5 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 import type { Script } from '../types/script';
-import { v4 as uuidv4 } from 'uuid';
 
 const initialState: Script[] = [];
 
@@ -8,24 +7,8 @@ const scriptSlice = createSlice({
   name: 'scripts',
   initialState,
   reducers: {
-    addScript: {
-      reducer(state, action: PayloadAction<Script>) {
-        state.push(action.payload);
-      },
-      prepare(
-        script: Omit<Script, 'id'> & {
-          /** Optional parent folder id */
-          parentId?: string;
-        }
-      ) {
-        return {
-          payload: {
-            ...script,
-            id: uuidv4(),
-            parentId: script.parentId,
-          },
-        };
-      },
+    addScript(state, action: PayloadAction<Script>) {
+      state.push(action.payload);
     },
     updateScript(
       state,


### PR DESCRIPTION
## Summary
- update `addScript` reducer to accept pre-built script objects
- implement new snippet creation flow in the panel with immediate edit state
- support `uuidv4` for direct form creation
- adapt tests for new `addScript` API

## Testing
- `npm run lint`
- `npm run type-check`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687956ad57f4832085afc0d11e737398