### PR TITLE
Add selection state to script list

### DIFF
--- a/src/components/ScriptList.tsx
+++ b/src/components/ScriptList.tsx
@@ -9,9 +9,16 @@ interface ScriptListProps {
   onEdit: (script: Script) => void;
   /** Filter text applied to name, description or code */
   filterText?: string;
+  /** Currently selected script id for highlighting */
+  selectedId?: string | null;
 }
 
-const ScriptList: React.FC<ScriptListProps> = ({ onRun, onEdit, filterText }) => {
+const ScriptList: React.FC<ScriptListProps> = ({
+  onRun,
+  onEdit,
+  filterText,
+  selectedId,
+}) => {
   const scripts = useAppSelector((state) => state.scripts);
   const dispatch = useAppDispatch();
 
@@ -31,7 +38,7 @@ const ScriptList: React.FC<ScriptListProps> = ({ onRun, onEdit, filterText }) =>
         {filtered.map((s) => (
           <tr
             key={s.id}
-            className="cursor-pointer border-b last:border-none hover:bg-zinc-700"
+            className={`cursor-pointer border-b last:border-none hover:bg-zinc-700 ${s.id === selectedId ? 'bg-zinc-700' : ''}`}
             onClick={() => onEdit(s)}
           >
             <td className="py-1">{s.name}</td>

--- a/src/components/__tests__/ScriptList.test.tsx
+++ b/src/components/__tests__/ScriptList.test.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import ScriptList from '../ScriptList';
+
+const scripts = [
+  { id: '1', name: 'first', description: '', code: '' },
+  { id: '2', name: 'second', description: '', code: '' },
+];
+
+const mockDispatch = jest.fn();
+
+jest.mock('../../store', () => ({
+  useAppSelector: (selector: any) => selector({ scripts }),
+  useAppDispatch: () => mockDispatch,
+}));
+
+describe('ScriptList row selection', () => {
+  it('adds highlight class to selected row', () => {
+    render(
+      <ScriptList onRun={jest.fn()} onEdit={jest.fn()} selectedId="2" />
+    );
+    const selectedRow = screen.getByText('second').closest('tr');
+    const otherRow = screen.getByText('first').closest('tr');
+    expect(selectedRow).toHaveClass('bg-zinc-700');
+    expect(otherRow).not.toHaveClass('bg-zinc-700');
+  });
+});

--- a/src/pages/Panel/Panel.tsx
+++ b/src/pages/Panel/Panel.tsx
@@ -69,6 +69,7 @@ const Panel: React.FC<PanelProps> = ({ inspectedTabId }) => {
             }}
             onEdit={setEditingScript}
             filterText={filter}
+            selectedId={editingScript?.id}
           />
         </div>
         <div className="w-2/3 overflow-y-auto pl-4">


### PR DESCRIPTION
## Summary
- allow `ScriptList` rows to be highlighted when editing
- pass `editingScript` id from panel to `ScriptList`
- test highlighting of selected row

## Testing
- `npm run lint`
- `npm run type-check`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6879cc26d89083208b0aae4959a45921