### PR TITLE
Add default snippet and auto-select first

### DIFF
--- a/src/components/ScriptForm.tsx
+++ b/src/components/ScriptForm.tsx
@@ -3,7 +3,6 @@ import CodeMirror, { ReactCodeMirrorRef } from '@uiw/react-codemirror';
 import { javascript } from '@codemirror/lang-javascript';
 import { useAppDispatch } from '../store';
 import { addScript, updateScript } from '../store/scriptSlice';
-import { v4 as uuidv4 } from 'uuid';
 import type { Script } from '../types/script';
 
 interface ScriptFormProps {
@@ -90,7 +89,7 @@ const ScriptForm: React.FC<ScriptFormProps> = ({ script, onSave }) => {
       console.warn(
         'ScriptForm: Adding new script directly from form (not via "Create New Snippet" button).'
       );
-      dispatch(addScript({ id: uuidv4(), name, description: '', code }));
+      dispatch(addScript({ name, description: '', code }));
       setName('');
       setCode('');
     }

--- a/src/pages/Panel/Panel.tsx
+++ b/src/pages/Panel/Panel.tsx
@@ -5,7 +5,6 @@ import ScriptList from '../../components/ScriptList';
 import type { Script } from '../../types/script';
 import { useAppDispatch, useAppSelector } from '../../store';
 import { addScript } from '../../store/scriptSlice';
-import { v4 as uuidv4 } from 'uuid';
 
 interface PanelProps {
   inspectedTabId: number;
@@ -14,18 +13,19 @@ interface PanelProps {
 const Panel: React.FC<PanelProps> = ({ inspectedTabId }) => {
   const dispatch = useAppDispatch();
   const scripts = useAppSelector((state) => state.scripts);
-  const [editingScript, setEditingScript] = useState<Script | null>(null);
+  const [editingScript, setEditingScript] = useState<Script | null>(
+    scripts.length > 0 ? scripts[0] : null
+  );
   const [filter, setFilter] = useState('');
 
   const handleAddNewScript = () => {
-    const newScript: Script = {
-      id: uuidv4(),
+    const action = addScript({
       name: `Snippet #${scripts.length + 1}`,
       description: '',
       code: '// Your JavaScript code here',
-    };
-    dispatch(addScript(newScript));
-    setEditingScript(newScript);
+    });
+    dispatch(action);
+    setEditingScript(action.payload);
   };
 
   return (

--- a/src/pages/Panel/Panel.tsx
+++ b/src/pages/Panel/Panel.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { X, FilePlus } from 'lucide-react';
 import ScriptForm from '../../components/ScriptForm';
 import ScriptList from '../../components/ScriptList';
@@ -16,6 +16,14 @@ const Panel: React.FC<PanelProps> = ({ inspectedTabId }) => {
   const [editingScript, setEditingScript] = useState<Script | null>(
     scripts.length > 0 ? scripts[0] : null
   );
+
+  useEffect(() => {
+    if (scripts.length === 0) {
+      setEditingScript(null);
+    } else if (!editingScript || !scripts.some((s) => s.id === editingScript.id)) {
+      setEditingScript(scripts[0]);
+    }
+  }, [scripts, editingScript]);
   const [filter, setFilter] = useState('');
 
   const handleAddNewScript = () => {
@@ -73,10 +81,12 @@ const Panel: React.FC<PanelProps> = ({ inspectedTabId }) => {
           />
         </div>
         <div className="w-2/3 overflow-y-auto pl-4">
-          <ScriptForm
-            script={editingScript || undefined}
-            onSave={() => setEditingScript(null)}
-          />
+          {editingScript && (
+            <ScriptForm
+              script={editingScript}
+              onSave={() => setEditingScript(null)}
+            />
+          )}
         </div>
       </div>
     </div>

--- a/src/pages/Panel/Panel.tsx
+++ b/src/pages/Panel/Panel.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import { X, FilePlus } from 'lucide-react';
 import ScriptForm from '../../components/ScriptForm';
 import ScriptList from '../../components/ScriptList';
@@ -16,14 +16,29 @@ const Panel: React.FC<PanelProps> = ({ inspectedTabId }) => {
   const [editingScript, setEditingScript] = useState<Script | null>(
     scripts.length > 0 ? scripts[0] : null
   );
+  const didInit = useRef(false);
 
   useEffect(() => {
+    if (!didInit.current) {
+      didInit.current = true;
+      if (scripts.length === 0) {
+        const action = addScript({
+          name: 'Snippet #1',
+          description: 'Your first code snippet.',
+          code: '// write or paste your snippet code here',
+        });
+        dispatch(action);
+        setEditingScript(action.payload);
+        return;
+      }
+    }
+
     if (scripts.length === 0) {
       setEditingScript(null);
     } else if (!editingScript || !scripts.some((s) => s.id === editingScript.id)) {
       setEditingScript(scripts[0]);
     }
-  }, [scripts, editingScript]);
+  }, [scripts, dispatch]);
   const [filter, setFilter] = useState('');
 
   const handleAddNewScript = () => {

--- a/src/store/__tests__/storePersistence.test.ts
+++ b/src/store/__tests__/storePersistence.test.ts
@@ -1,6 +1,5 @@
 import { setPatched } from '../settingsSlice';
 import { addScript } from '../scriptSlice';
-import { v4 as uuidv4 } from 'uuid';
 
 describe('store persistence', () => {
   beforeEach(() => {
@@ -59,7 +58,6 @@ describe('store persistence', () => {
 
     store.dispatch(
       addScript({
-        id: uuidv4(),
         name: 'demo',
         description: '',
         code: 'console.log(1);',

--- a/src/store/scriptSlice.ts
+++ b/src/store/scriptSlice.ts
@@ -1,14 +1,27 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 import type { Script } from '../types/script';
+import { v4 as uuidv4 } from 'uuid';
 
-const initialState: Script[] = [];
+const initialState: Script[] = [
+  {
+    id: uuidv4(),
+    name: 'Snippet #1',
+    description: 'Your first code snippet.',
+    code: '// write or paste your snippet code here',
+  },
+];
 
 const scriptSlice = createSlice({
   name: 'scripts',
   initialState,
   reducers: {
-    addScript(state, action: PayloadAction<Script>) {
-      state.push(action.payload);
+    addScript: {
+      reducer(state, action: PayloadAction<Script>) {
+        state.push(action.payload);
+      },
+      prepare(script: Omit<Script, 'id'>) {
+        return { payload: { ...script, id: uuidv4() } };
+      },
     },
     updateScript(
       state,


### PR DESCRIPTION
## Summary
- prepopulate the script store with a demo snippet
- assign ids on script creation in the slice
- pick the first snippet for editing on panel load
- adapt ScriptForm and tests for new action signature

## Testing
- `npm run lint`
- `npm test`
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_687a56f29ac883208fccf70dc53be6ec