### PR TITLE
feat: allow editing from snippet row

### DIFF
--- a/src/components/ScriptList.tsx
+++ b/src/components/ScriptList.tsx
@@ -42,25 +42,31 @@ const ScriptList: React.FC<ScriptListProps> = ({
             onClick={() => onEdit(s)}
           >
             <td className="py-1">{s.name}</td>
-            <td
-              className="py-1 text-right"
-              onClick={(e) => e.stopPropagation()}
-            >
+            <td className="py-1 text-right">
               <button
                 className="mr-2 text-blue-500 hover:text-blue-700"
-                onClick={() => onRun(s)}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onRun(s);
+                }}
               >
                 <Play size={16} />
               </button>
               <button
                 className="mr-2 text-yellow-500 hover:text-yellow-700"
-                onClick={() => onEdit(s)}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onEdit(s);
+                }}
               >
                 <Edit size={16} />
               </button>
               <button
                 className="text-red-500 hover:text-red-700"
-                onClick={() => dispatch(deleteScript(s.id))}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  dispatch(deleteScript(s.id));
+                }}
               >
                 <Trash2 size={16} />
               </button>

--- a/src/components/__tests__/ScriptList.test.tsx
+++ b/src/components/__tests__/ScriptList.test.tsx
@@ -24,4 +24,12 @@ describe('ScriptList row selection', () => {
     expect(selectedRow).toHaveClass('bg-zinc-700');
     expect(otherRow).not.toHaveClass('bg-zinc-700');
   });
+
+  it('triggers onEdit when row is clicked', () => {
+    const onEdit = jest.fn();
+    render(<ScriptList onRun={jest.fn()} onEdit={onEdit} />);
+    const firstRow = screen.getByText('first').closest('tr');
+    firstRow?.click();
+    expect(onEdit).toHaveBeenCalledWith(scripts[0]);
+  });
 });


### PR DESCRIPTION
## Summary
- enable edit mode when clicking anywhere on snippet row
- test row click to trigger edit

## Testing
- `npm run lint`
- `npm test`
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_687a742965fc83208f477e0714abf0be